### PR TITLE
FTFunction maps to "functional" in the JSON schema

### DIFF
--- a/src/VegaLite.elm
+++ b/src/VegaLite.elm
@@ -14244,7 +14244,7 @@ fieldTitleLabel ftp =
             "verbal"
 
         FTFunction ->
-            "function"
+            "functional"
 
         FTPlain ->
             "plain"


### PR DESCRIPTION
Version 3.3.0 of the Vega-Lite spec says that the fieldTitle takes "verbal", "functional", or "plain"

https://github.com/vega/schema/blob/master/vega-lite/v3.3.0.json#L3139

(I noted this when I was updating hvega)