### PR TITLE
GalleryAdvanced: minor VegaLite spec tweaks

### DIFF
--- a/test-gallery/src/GalleryAdvanced.elm
+++ b/test-gallery/src/GalleryAdvanced.elm
@@ -217,7 +217,7 @@ advanced6 =
         enc1 =
             encoding
                 << position Y [ pName "previous_sum", pMType Quantitative, pTitle "Amount" ]
-                << position Y2 [ pName "sum", pMType Quantitative ]
+                << position Y2 [ pName "sum" ]
                 << color
                     [ mDataCondition
                         [ ( expr "datum.label === 'Begin' || datum.label === 'End'", [ mStr "#f7e0b6" ] )
@@ -231,7 +231,7 @@ advanced6 =
 
         enc2 =
             encoding
-                << position X2 [ pName "lead", pMType Ordinal ]
+                << position X2 [ pName "lead" ]
                 << position Y [ pName "sum", pMType Quantitative ]
 
         spec2 =
@@ -363,10 +363,10 @@ advanced8 =
                 << color [ mName "species", mMType Nominal ]
                 << detail [ dName "index", dMType Nominal ]
                 << tooltips
-                    [ [ tName "petalLength" ]
-                    , [ tName "petalWidth" ]
-                    , [ tName "sepalLength" ]
-                    , [ tName "sepalWidth" ]
+                    [ [ tName "petalLength", tMType Quantitative ]
+                    , [ tName "petalWidth", tMType Quantitative ]
+                    , [ tName "sepalLength", tMType Quantitative ]
+                    , [ tName "sepalWidth", tMType Quantitative ]
                     ]
 
         specLine =


### PR DESCRIPTION
The VegaLite spec doesn't like people giving a type for the *2 channels, and also it wants a type for the tooltips. The plot looks okay without these changes, but I thought I'd pass it on.

I originally noticed the *2 channel issue somewhere else in elm-vegalite, but forget where, so this is more a "hey, this could be done" rather than a "I've fixed up all occurrences of it".