### PR TITLE
Tweak tests for Vega-Lite 4.1 compliance

### DIFF
--- a/test-gallery/src/GalleryMulti.elm
+++ b/test-gallery/src/GalleryMulti.elm
@@ -165,10 +165,10 @@ multi4 =
 
         enc1 =
             encoding
-                << color [ mAggregate opCount, mQuant, mLegend [ leTitle "" ] ]
+                << color [ mAggregate opCount, mQuant, mLegend [ leTitle "All Movies", leDirection MOHorizontal, leGradientLength 120 ] ]
 
         spec1 =
-            asSpec [ width 300, rect [], enc1 [] ]
+            asSpec [ rect [], enc1 [] ]
 
         enc2 =
             encoding

--- a/tests/src/GeoTests.elm
+++ b/tests/src/GeoTests.elm
@@ -421,23 +421,19 @@ mapComp3 =
             let
                 graticuleSpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ prType orthographic, prRotate rot 0 0 ]
+                        [ projection [ prType orthographic, prRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ topojsonFeature "graticule" ]
                         , geoshape [ maFilled False, maStroke "#411", maStrokeWidth 0.1 ]
                         ]
 
                 countrySpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ prType orthographic, prRotate rot 0 0 ]
+                        [ projection [ prType orthographic, prRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ topojsonFeature "countries" ]
                         , geoshape [ maStroke "white", maFill "black", maStrokeWidth 0.5 ]
                         ]
             in
-            asSpec [ layer [ graticuleSpec, countrySpec ] ]
+            asSpec [ width 300, height 300, layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
         [ configure <| configuration (coView [ vicoStroke Nothing ]) <| [], hConcat [ rotatedSpec -65, rotatedSpec 115, rotatedSpec -65 ] ]
@@ -450,32 +446,26 @@ mapComp4 =
             let
                 seaSpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ prType orthographic, prRotate 0 0 0 ]
+                        [ projection [ prType orthographic, prRotate 0 0 0 ]
                         , dataFromUrl "data/globe.json" [ topojsonFeature "globe" ]
                         , geoshape [ maFill "#c1e7f5", maStrokeOpacity 0 ]
                         ]
 
                 graticuleSpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ prType orthographic, prRotate rot 0 0 ]
+                        [ projection [ prType orthographic, prRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ topojsonFeature "graticule" ]
                         , geoshape [ maFilled False, maStroke "#411", maStrokeWidth 0.1 ]
                         ]
 
                 countrySpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ prType orthographic, prRotate rot 0 0 ]
+                        [ projection [ prType orthographic, prRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ topojsonFeature "countries" ]
                         , geoshape [ maStroke "white", maFill "#242", maStrokeWidth 0.1 ]
                         ]
             in
-            asSpec [ layer [ seaSpec, graticuleSpec, countrySpec ] ]
+            asSpec [ width 300, height 300, layer [ seaSpec, graticuleSpec, countrySpec ] ]
     in
     toVegaLite
         [ configure <| configuration (coView [ vicoStroke Nothing ]) <| [], hConcat [ rotatedSpec 0, rotatedSpec -40 ] ]


### PR DESCRIPTION
It looks like Vega-Lite 4.1 no-longer likes you setting the width or height within a layer. I haven't tracked down the change in the schema, so I may be over-simplifying the change. I also have not actually compiled these changes, so there may be errors here! It was just easier to describe the changes in code than text!